### PR TITLE
Add SONiC network health assertion toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
 # health_assertion
+
+Toolkit for performing automated health assertions against [SONiC](https://sonic-net.github.io/SONiC/) switches. The tool connects over SSH, runs configurable commands, validates the output against expectations, and emits alerts.
+
+## Features
+
+- YAML-based configuration describing switches and command checks.
+- Extensible check types (substring and regular-expression matching).
+- Automatic retries for flaky commands.
+- Alert destinations including stdout, log files, and Slack webhooks.
+
+## Getting started
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Create a configuration file similar to [`example_config.yaml`](example_config.yaml) with the switches you want to monitor and the checks to run.
+
+3. Execute the health assertion runner:
+
+   ```bash
+   python -m health_assertion path/to/your_config.yaml
+   ```
+
+   The command will connect to each switch, execute the configured checks, and emit alerts according to the `alerts` configuration section.
+
+## Configuration reference
+
+Each switch entry supports the following keys:
+
+| Key | Description |
+| --- | --- |
+| `name` | Friendly name for the switch (used in alerts). |
+| `host` | Hostname or IP address of the switch. |
+| `username` | SSH username. |
+| `password` | SSH password (optional if using key-based auth). |
+| `port` | SSH port (default `22`). |
+| `timeout` | SSH connection timeout in seconds (default `30`). |
+| `checks` | List of command checks to execute. |
+
+Supported check types:
+
+- `command_contains`: checks that the command output contains an expected substring (`expect`).
+- `command_regex`: checks that the command output matches a regular expression (`pattern`).
+
+## Alert destinations
+
+Configure alert outputs in the `alerts` block:
+
+- `stdout`: Write alerts to standard output (`true` by default).
+- `file`: Append alerts to a log file (directories are created if needed).
+- `slack_webhook`: Send alerts to a Slack channel using an incoming webhook URL.
+
+## Extending the tool
+
+The implementation is modular. To add new check types or alert destinations, extend the modules inside `src/health_assertion`.

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,0 +1,23 @@
+# Example configuration for the network health assertion toolkit
+switches:
+  - name: leaf01
+    host: 10.10.10.11
+    username: admin
+    password: your-password
+    port: 22
+    timeout: 30
+    checks:
+      - type: command_contains
+        command: show system-health
+        expect: Overall system state: OK
+        severity: critical
+        description: System health should report OK
+      - type: command_regex
+        command: show interface status Ethernet0
+        pattern: "Ethernet0\\s+up\\s+up"
+        severity: warning
+        description: Ethernet0 should be up/up
+alerts:
+  stdout: true
+  file: logs/health_alerts.log
+  # slack_webhook: https://hooks.slack.com/services/XXXX/XXXX

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "health_assertion"
+version = "0.1.0"
+description = "SONiC network health assertion toolkit"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+authors = [{name = "Network Automation"}]
+dependencies = [
+    "paramiko>=3.4",
+    "PyYAML>=6.0",
+    "requests>=2.32",
+    "tenacity>=8.2",
+]
+
+[project.scripts]
+health-assertion = "health_assertion.__main__:main"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+paramiko>=3.4
+PyYAML>=6.0
+requests>=2.32
+tenacity>=8.2

--- a/src/health_assertion/__init__.py
+++ b/src/health_assertion/__init__.py
@@ -1,0 +1,5 @@
+"""Network health assertion toolkit for SONiC switches."""
+
+from .runner import run_health_checks
+
+__all__ = ["run_health_checks"]

--- a/src/health_assertion/__main__.py
+++ b/src/health_assertion/__main__.py
@@ -1,0 +1,33 @@
+"""CLI entrypoint for the health assertion toolkit."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from .config import Settings
+from .runner import run_health_checks
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="SONiC network health assertion toolkit")
+    parser.add_argument("config", type=Path, help="Path to the YAML configuration file")
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set the logging level",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level))
+    settings = Settings.load(args.config)
+    run_health_checks(settings)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/health_assertion/alerting.py
+++ b/src/health_assertion/alerting.py
@@ -1,0 +1,60 @@
+"""Alerting helpers for the health assertion toolkit."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import requests
+
+from .checks import CheckResult
+from .config import AlertConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _format_message(result: CheckResult) -> str:
+    status = "PASSED" if result.success else "FAILED"
+    timestamp = datetime.utcnow().isoformat()
+    return (
+        f"[{timestamp}] {status} ({result.severity.upper()}) {result.switch}: "
+        f"{result.description}\n{result.expectation}\nOutput:\n{result.output.strip()}"
+    )
+
+
+def emit_stdout(results: Iterable[CheckResult]) -> None:
+    for result in results:
+        print(_format_message(result))
+
+
+def emit_file(results: Iterable[CheckResult], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for result in results:
+            handle.write(_format_message(result) + "\n")
+
+
+def emit_slack(results: Iterable[CheckResult], webhook: str) -> None:
+    for result in results:
+        message = _format_message(result)
+        payload = {"text": message}
+        response = requests.post(webhook, data=json.dumps(payload), headers={"Content-Type": "application/json"})
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            logger.error("Failed to send Slack alert: %s", response.text)
+
+
+def send_alerts(config: AlertConfig, results: List[CheckResult]) -> None:
+    """Dispatch alerts according to the configuration."""
+
+    if config.stdout:
+        emit_stdout(results)
+    if config.file:
+        emit_file(results, config.file)
+    if config.slack_webhook:
+        emit_slack(results, config.slack_webhook)

--- a/src/health_assertion/checks.py
+++ b/src/health_assertion/checks.py
@@ -1,0 +1,70 @@
+"""Assertion checks run against SONiC switches."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from .config import CommandCheckConfig
+from .sonic_client import run_command
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CheckResult:
+    """Result of executing a single check."""
+
+    switch: str
+    description: str
+    severity: str
+    success: bool
+    output: str
+    expectation: str
+
+
+CheckExecutor = Callable[[CommandCheckConfig, str], CheckResult]
+
+
+def execute_command_contains(config: CommandCheckConfig, output: str, switch: str) -> CheckResult:
+    success = config.expect in output
+    expectation = f"Expected substring '{config.expect}'"
+    return CheckResult(
+        switch=switch,
+        description=config.description or f"Command '{config.command}' contains substring",
+        severity=config.severity,
+        success=success,
+        output=output,
+        expectation=expectation,
+    )
+
+
+def execute_command_regex(config: CommandCheckConfig, output: str, switch: str) -> CheckResult:
+    pattern = re.compile(config.pattern or "")
+    match = pattern.search(output)
+    expectation = f"Expected pattern '{config.pattern}'"
+    return CheckResult(
+        switch=switch,
+        description=config.description or f"Command '{config.command}' matches regex",
+        severity=config.severity,
+        success=bool(match),
+        output=output,
+        expectation=expectation,
+    )
+
+
+EXECUTORS: dict[str, Callable[[CommandCheckConfig, str, str], CheckResult]] = {
+    "command_contains": execute_command_contains,
+    "command_regex": execute_command_regex,
+}
+
+
+def run_check(client, switch: str, config: CommandCheckConfig) -> CheckResult:
+    """Run an individual check on the given SSH client."""
+
+    logger.info("Running check '%s' on %s", config.description or config.command, switch)
+    output = run_command(client, config.command)
+    executor = EXECUTORS[config.type]
+    return executor(config, output, switch)

--- a/src/health_assertion/config.py
+++ b/src/health_assertion/config.py
@@ -1,0 +1,96 @@
+"""Configuration parsing utilities for the health assertion toolkit."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import yaml
+
+
+@dataclass
+class CommandCheckConfig:
+    """Configuration required to execute a command based assertion."""
+
+    type: str
+    command: str
+    expect: Optional[str] = None
+    pattern: Optional[str] = None
+    severity: str = "warning"
+    description: Optional[str] = None
+
+    def validate(self) -> None:
+        if self.type not in {"command_contains", "command_regex"}:
+            raise ValueError(f"Unsupported check type: {self.type}")
+        if self.type == "command_contains" and not self.expect:
+            raise ValueError("command_contains check requires 'expect'")
+        if self.type == "command_regex" and not self.pattern:
+            raise ValueError("command_regex check requires 'pattern'")
+
+
+@dataclass
+class SwitchConfig:
+    """Connection information for a SONiC switch and its checks."""
+
+    name: str
+    host: str
+    username: str
+    password: Optional[str] = None
+    port: int = 22
+    timeout: int = 30
+    commands: List[CommandCheckConfig] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "SwitchConfig":
+        commands = [CommandCheckConfig(**cmd) for cmd in data.get("checks", [])]
+        for command in commands:
+            command.validate()
+        return cls(
+            name=data["name"],
+            host=data["host"],
+            username=data["username"],
+            password=data.get("password"),
+            port=data.get("port", 22),
+            timeout=data.get("timeout", 30),
+            commands=commands,
+        )
+
+
+@dataclass
+class AlertConfig:
+    """Settings controlling how alerts are emitted."""
+
+    stdout: bool = True
+    file: Optional[Path] = None
+    slack_webhook: Optional[str] = None
+
+
+@dataclass
+class Settings:
+    """Top level configuration describing switches and alerting destinations."""
+
+    switches: List[SwitchConfig]
+    alerting: AlertConfig
+
+    @classmethod
+    def load(cls, path: Path) -> "Settings":
+        data = yaml.safe_load(path.read_text())
+        if not data:
+            raise ValueError("Configuration file is empty")
+        switches = [SwitchConfig.from_dict(item) for item in data.get("switches", [])]
+        if not switches:
+            raise ValueError("No switches defined in configuration")
+        alert_data = data.get("alerts", {})
+        alerting = AlertConfig(
+            stdout=alert_data.get("stdout", True),
+            file=Path(alert_data["file"]) if alert_data.get("file") else None,
+            slack_webhook=alert_data.get("slack_webhook"),
+        )
+        return cls(switches=switches, alerting=alerting)
+
+
+def iter_switches(settings: Settings) -> Iterable[SwitchConfig]:
+    """Helper to iterate switches in the configuration."""
+
+    yield from settings.switches

--- a/src/health_assertion/runner.py
+++ b/src/health_assertion/runner.py
@@ -1,0 +1,66 @@
+"""Main orchestration logic for running health checks."""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+from .alerting import send_alerts
+from .checks import CheckResult, run_check
+from .config import Settings, iter_switches
+from .sonic_client import SSHCredentials, sonic_ssh_client
+
+logger = logging.getLogger(__name__)
+
+
+@retry(wait=wait_fixed(2), stop=stop_after_attempt(3), reraise=True)
+def _run_check_with_retry(client, switch: str, check_config) -> CheckResult:
+    return run_check(client, switch, check_config)
+
+
+def run_health_checks(settings: Settings) -> List[CheckResult]:
+    """Run health checks for all switches defined in the settings."""
+
+    results: List[CheckResult] = []
+    for switch in iter_switches(settings):
+        credentials = SSHCredentials(
+            host=switch.host,
+            username=switch.username,
+            password=switch.password,
+            port=switch.port,
+            timeout=switch.timeout,
+        )
+        try:
+            with sonic_ssh_client(credentials) as client:
+                for command in switch.commands:
+                    try:
+                        result = _run_check_with_retry(client, switch.name, command)
+                        results.append(result)
+                    except Exception as exc:  # pragma: no cover - defensive logging
+                        logger.exception("Check %s on %s failed", command.command, switch.name)
+                        results.append(
+                            CheckResult(
+                                switch=switch.name,
+                                description=command.description or command.command,
+                                severity=command.severity,
+                                success=False,
+                                output=str(exc),
+                                expectation="Check execution completed without exception",
+                            )
+                        )
+        except Exception as exc:
+            logger.exception("Failed to connect to %s", switch.name)
+            results.append(
+                CheckResult(
+                    switch=switch.name,
+                    description="Connection failure",
+                    severity="critical",
+                    success=False,
+                    output=str(exc),
+                    expectation="SSH connection should succeed",
+                )
+            )
+    send_alerts(settings.alerting, results)
+    return results

--- a/src/health_assertion/sonic_client.py
+++ b/src/health_assertion/sonic_client.py
@@ -1,0 +1,58 @@
+"""SSH client helpers for interacting with SONiC switches."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterator, Optional
+
+import paramiko
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SSHCredentials:
+    """Credentials used to connect to a SONiC device."""
+
+    host: str
+    username: str
+    password: Optional[str]
+    port: int = 22
+    timeout: int = 30
+
+
+@contextmanager
+def sonic_ssh_client(credentials: SSHCredentials) -> Iterator[paramiko.SSHClient]:
+    """Context manager that yields a connected SSH client."""
+
+    logger.debug("Connecting to %s:%s", credentials.host, credentials.port)
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    try:
+        client.connect(
+            credentials.host,
+            port=credentials.port,
+            username=credentials.username,
+            password=credentials.password,
+            timeout=credentials.timeout,
+        )
+        logger.debug("Connected to %s", credentials.host)
+        yield client
+    finally:
+        logger.debug("Closing SSH connection to %s", credentials.host)
+        client.close()
+
+
+def run_command(client: paramiko.SSHClient, command: str, timeout: Optional[int] = None) -> str:
+    """Execute a command on the SSH client and return its output."""
+
+    logger.debug("Executing command: %s", command)
+    stdin, stdout, stderr = client.exec_command(command, timeout=timeout)
+    output = stdout.read().decode("utf-8")
+    error = stderr.read().decode("utf-8")
+    if error:
+        logger.debug("Command produced stderr: %s", error.strip())
+    logger.debug("Command output: %s", output.strip())
+    return output


### PR DESCRIPTION
## Summary
- add a modular SONiC health assertion runner that executes SSH-based command checks and centralizes alert handling
- support YAML-driven configuration, CLI entrypoint, and packaging metadata for the toolkit
- document usage and provide an example configuration for onboarding

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e17c864bec832e8241ac4e23dff107